### PR TITLE
Parameter validation refactor

### DIFF
--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -68,24 +68,50 @@
 #define MBEDTLS_ERR_AES_HW_ACCEL_FAILED                   -0x0025  /**< AES hardware accelerator failed. */
 
 #if defined( MBEDTLS_CHECK_PARAMS )
-#define MBEDTLS_AES_VALIDATE_RET( cond )  do{ if( !(cond)  ) {                 \
-                                            mbedtls_param_failed( #cond,       \
-                                                                  __FILE__,    \
-                                                                  __LINE__ );  \
-                                            return MBEDTLS_ERR_AES_BAD_INPUT_DATA;} \
-                                          } while(0);
 
-#define MBEDTLS_AES_VALIDATE( cond )      do{ if( !(cond)  ) {                 \
-                                            mbedtls_param_failed( #cond,       \
-                                                                  __FILE__,    \
-                                                                  __LINE__ );  \
-                                            return; }                          \
-                                          } while(0);
-#else
+#if defined(MBEDTLS_PARAM_FAILED_CALLBACK)
+
+#define MBEDTLS_AES_VALIDATE_RET( cond )                                \
+    do{                                                                 \
+        if( !(cond) ) {                                                 \
+            mbedtls_param_failed( #cond,                                \
+                                  __FILE__,                             \
+                                  __LINE__ );                           \
+            return MBEDTLS_ERR_AES_BAD_INPUT_DATA;                      \
+        }                                                               \
+    } while(0)
+
+#define MBEDTLS_AES_VALIDATE( cond )                                    \
+    do {                                                                \
+        if( !(cond) ) {                                                 \
+            mbedtls_param_failed( #cond,                                \
+                                  __FILE__,                             \
+                                  __LINE__ );                           \
+            return;                                                     \
+        }                                                               \
+    } while(0)
+
+#else /* MBEDTLS_PARAM_FAILED_CALLBACK */
+
+#define MBEDTLS_AES_VALIDATE_RET( cond )                                \
+    do {                                                                \
+        if( !(cond) ) {                                                 \
+            return MBEDTLS_ERR_AES_BAD_INPUT_DATA;                      \
+        }                                                               \
+    } while(0)
+
+#define MBEDTLS_AES_VALIDATE( cond )            \
+    do { if( !(cond) ) { return; } } while(0)
+
+#endif /* MBEDTLS_PARAM_FAILED_CALLBACK */
+
+#else /* MBEDTLS_CHECK_PARAMS */
+
 /* No validation of parameters will be performed */
 #define MBEDTLS_AES_VALIDATE_RET( cond )
-#define MBEDTLS_AES_VALIDATE( cond)
-#endif
+#define MBEDTLS_AES_VALIDATE( cond )
+
+#endif /* MBEDTLS_CHECK_PARAMS */
 
 #if ( defined(__ARMCC_VERSION) || defined(_MSC_VER) ) && \
     !defined(inline) && !defined(__cplusplus)

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -69,14 +69,14 @@
 
 #if defined( MBEDTLS_CHECK_PARAMS )
 #define MBEDTLS_AES_VALIDATE_RET( cond )  do{ if( !(cond)  ) {                 \
-                                            MBEDTLS_PARAM_FAILED( #cond,       \
+                                            mbedtls_param_failed( #cond,       \
                                                                   __FILE__,    \
                                                                   __LINE__ );  \
                                             return MBEDTLS_ERR_AES_BAD_INPUT_DATA;} \
                                           } while(0);
 
 #define MBEDTLS_AES_VALIDATE( cond )      do{ if( !(cond)  ) {                 \
-                                            MBEDTLS_PARAM_FAILED( #cond,       \
+                                            mbedtls_param_failed( #cond,       \
                                                                   __FILE__,    \
                                                                   __LINE__ );  \
                                             return; }                          \

--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -66,6 +66,10 @@
 #error "MBEDTLS_HAVE_TIME_DATE without MBEDTLS_HAVE_TIME does not make sense"
 #endif
 
+#if defined(MBEDTLS_PARAM_FAILED_CALLBACK) && !defined(MBEDTLS_CHECK_PARAMS)
+#error "MBEDTLS_PARAM_FAILED_CALLBACK defined, but not all prerequisites"
+#endif
+
 #if defined(MBEDTLS_AESNI_C) && !defined(MBEDTLS_HAVE_ASM)
 #error "MBEDTLS_AESNI_C defined, but not all prerequisites"
 #endif

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -275,6 +275,30 @@
  */
 #define MBEDTLS_CHECK_PARAMS
 
+/**
+ * \def MBEDTLS_PARAM_FAILED_CALLBACK
+ *
+ * Enable or disable parameter validation callback upon validation failure.
+ *
+ * The parameter validation failure may be handled in different ways. In most
+ * functions, the preferred reaction is to immediately return with an error
+ * code. However, some functions do not return an error code, but they take
+ * parameters, that need to be validated. In such case, Mbed TLS, besides
+ * returning from the function, will call a special failure callback function.
+ * The library provides a default implementation of that and allows supplying
+ * a user defined alternative.
+ *
+ * When this symbol is defined, the parameter validation callback will be
+ * compiled in and called upon the parameter validation failure.
+ *
+ * When this symbol is not defined, parameter validation will be limited to
+ * immediate returns of error codes, or just returns in the functions of void
+ * return type.
+ *
+ * Requires MBEDTLS_CHECK_PARAMS
+ */
+#define MBEDTLS_PARAM_FAILED_CALLBACK
+
 /* \} name SECTION: System support */
 
 /**

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -3015,9 +3015,6 @@
 //#define MBEDTLS_PLATFORM_NV_SEED_READ_MACRO   mbedtls_platform_std_nv_seed_read /**< Default nv_seed_read function to use, can be undefined */
 //#define MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO  mbedtls_platform_std_nv_seed_write /**< Default nv_seed_write function to use, can be undefined */
 
-//#define MBEDTLS_PARAM_FAILED(x)               mbedtls_param_failed( #x ) /**< Default parameter validation callback to use. Can be undefined */
-
-
 /* SSL Cache options */
 //#define MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT       86400 /**< 1 day  */
 //#define MBEDTLS_SSL_CACHE_DEFAULT_MAX_ENTRIES      50 /**< Maximum entries in cache */

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -41,10 +41,10 @@
 extern "C" {
 #endif
 
-#if defined(MBEDTLS_CHECK_PARAMS)
+#if defined(MBEDTLS_PARAM_FAILED_CALLBACK)
 extern void (*mbedtls_param_failed)( char *, char *, int );
 int mbedtls_set_param_failed( void (*param_failed_func)( char *, char *, int ) );
-#endif /* MBEDTLS_CHECK_PARAMS */
+#endif /* MBEDTLS_PARAM_FAILED_CALLBACK */
 
 /**
  * \brief       Securely zeroize a buffer

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -41,33 +41,10 @@
 extern "C" {
 #endif
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C) && \
-    !defined(MBEDTLS_PARAM_FAILED)
-#define MBEDTLS_PARAM_FAILED( cond, file, line )                               \
-                                        mbedtls_param_failed( cond, file, line )
-
-/**
- * \brief       User supplied callback function for parameter validation failure.
- *
- *              When the MBEDTLS_CHECK_PARAMS option is enabled, the library
- *              provides additional validation of all input parameters to
- *              confirm that they conform to what the interface can accept.
- *              For example - NULL paramater checks.
- *
- *              These checks are designed to check programmatic issues in the
- *              application software using Mbed TLS, or catch other runtime
- *              errors which may be due to issues in the application software.
- *
- *              This function will be called unless an alternative function is
- *              defined through the MBEDTLS_PARAM_FAILURE function.
- *
- *              This function can return, and the operation will be aborted, or
- *              alternatively, through use of setjmp()/longjmp() can resume
- *              execution in the application code.
- */
-void mbedtls_param_failed( char* failure_condition, char* file, int line );
-
-#endif /* MBEDTLS_CHECK_PARAMS && MBEDTLS_PLATFORM_C && !MBEDTLS_PARAM_FAILED */
+#if defined(MBEDTLS_CHECK_PARAMS)
+extern void (*mbedtls_param_failed)( char *, char *, int );
+int mbedtls_set_param_failed( void (*param_failed_func)( char *, char *, int ) );
+#endif /* MBEDTLS_CHECK_PARAMS */
 
 /**
  * \brief       Securely zeroize a buffer

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -42,8 +42,9 @@ extern "C" {
 #endif
 
 #if defined(MBEDTLS_PARAM_FAILED_CALLBACK)
-extern void (*mbedtls_param_failed)( char *, char *, int );
-int mbedtls_set_param_failed( void (*param_failed_func)( char *, char *, int ) );
+extern void (*mbedtls_param_failed)( const char *, const char *, int );
+int mbedtls_set_param_failed(
+    void (*param_failed_func)( const char *, const char *, int ) );
 #endif /* MBEDTLS_PARAM_FAILED_CALLBACK */
 
 /**

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -136,8 +136,8 @@ struct tm *mbedtls_platform_gmtime_r( const mbedtls_time_t *tt,
 #endif /* MBEDTLS_HAVE_TIME_DATE && MBEDTLS_PLATFORM_GMTIME_R_ALT */
 
 #if defined(MBEDTLS_PARAM_FAILED_CALLBACK)
-static void mbedtls_param_failed_default( char *failure_condition,
-                                          char *file,
+static void mbedtls_param_failed_default( const char *failure_condition,
+                                          const char *file,
                                           int line )
 {
 #if defined(MBEDTLS_PLATFORM_C)
@@ -151,11 +151,11 @@ static void mbedtls_param_failed_default( char *failure_condition,
 #endif /* MBEDTLS_PLATFORM_C */
 }
 
-void (*mbedtls_param_failed)( char *, char *, int ) =
+void (*mbedtls_param_failed)( const char *, const char *, int ) =
     mbedtls_param_failed_default;
 
 int mbedtls_set_param_failed(
-    void (*param_failed_func)( char *, char *, int ) )
+    void (*param_failed_func)( const char *, const char *, int ) )
 {
     mbedtls_param_failed = param_failed_func;
     return( 0 );

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -135,11 +135,31 @@ struct tm *mbedtls_platform_gmtime_r( const mbedtls_time_t *tt,
 }
 #endif /* MBEDTLS_HAVE_TIME_DATE && MBEDTLS_PLATFORM_GMTIME_R_ALT */
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C) && \
-    defined(MBEDTLS_DEBUG_INVALID_PARAMS)
-void mbedtls_param_failed( char* failure_condition )
-{
-    mbedtls_printf("%s:%i: Input param failed - %s\n", __FILE__, __LINE__,                           failure_condition );
-}
-#endif
+#if defined(MBEDTLS_CHECK_PARAMS)
 
+static void mbedtls_param_failed_default( char *failure_condition,
+                                          char *file,
+                                          int line )
+{
+#if defined(MBEDTLS_PLATFORM_C)
+    mbedtls_printf(
+        "%s:%i: Input param failed - %s\n", file, line, failure_condition );
+    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
+#else
+    (void)failure_condition;
+    (void)file;
+    (void)line;
+#endif /* MBEDTLS_PLATFORM_C */
+}
+
+void (*mbedtls_param_failed)( char *, char *, int ) =
+    mbedtls_param_failed_default;
+
+int mbedtls_set_param_failed(
+    void (*param_failed_func)( char *, char *, int ) )
+{
+    mbedtls_param_failed = param_failed_func;
+    return( 0 );
+}
+
+#endif /*  MBEDTLS_CHECK_PARAMS */

--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -135,8 +135,7 @@ struct tm *mbedtls_platform_gmtime_r( const mbedtls_time_t *tt,
 }
 #endif /* MBEDTLS_HAVE_TIME_DATE && MBEDTLS_PLATFORM_GMTIME_R_ALT */
 
-#if defined(MBEDTLS_CHECK_PARAMS)
-
+#if defined(MBEDTLS_PARAM_FAILED_CALLBACK)
 static void mbedtls_param_failed_default( char *failure_condition,
                                           char *file,
                                           int line )
@@ -162,4 +161,4 @@ int mbedtls_set_param_failed(
     return( 0 );
 }
 
-#endif /*  MBEDTLS_CHECK_PARAMS */
+#endif /* MBEDTLS_PARAM_FAILED_CALLBACK */

--- a/programs/aes/aescrypt2.c
+++ b/programs/aes/aescrypt2.c
@@ -79,15 +79,6 @@ int main( void )
 }
 #else
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %s\n", file, line,
-                   failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( int argc, char *argv[] )
 {
     int ret = 0;

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -81,15 +81,6 @@ int main( void )
 }
 #else
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %s\n", file, line,
-                   failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( int argc, char *argv[] )
 {
     int ret = 1, i, n;

--- a/programs/pkey/dh_client.c
+++ b/programs/pkey/dh_client.c
@@ -71,14 +71,6 @@ int main( void )
 }
 #else
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( void )
 {
     FILE *f;

--- a/programs/pkey/dh_genprime.c
+++ b/programs/pkey/dh_genprime.c
@@ -68,14 +68,6 @@ int main( void )
  */
 #define GENERATOR "4"
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( int argc, char **argv )
 {
     int ret = 1;

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -71,14 +71,6 @@ int main( void )
 }
 #else
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( void )
 {
     FILE *f;

--- a/programs/pkey/ecdh_curve25519.c
+++ b/programs/pkey/ecdh_curve25519.c
@@ -52,14 +52,6 @@ int main( void )
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/ecdh.h"
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( int argc, char *argv[] )
 {
     int ret = 1;

--- a/programs/pkey/ecdsa.c
+++ b/programs/pkey/ecdsa.c
@@ -99,14 +99,6 @@ static void dump_pubkey( const char *title, mbedtls_ecdsa_context *key )
 #define dump_pubkey( a, b )
 #endif
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( int argc, char *argv[] )
 {
     int ret = 1;

--- a/programs/pkey/gen_key.c
+++ b/programs/pkey/gen_key.c
@@ -136,14 +136,6 @@ int main( void )
 }
 #else
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 /*
  * global options
  */

--- a/programs/pkey/key_app.c
+++ b/programs/pkey/key_app.c
@@ -74,14 +74,6 @@ int main( void )
 }
 #else
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 /*
  * global options
  */

--- a/programs/pkey/key_app_writer.c
+++ b/programs/pkey/key_app_writer.c
@@ -95,14 +95,6 @@ int main( void )
 }
 #else
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 /*
  * global options
  */

--- a/programs/pkey/pk_decrypt.c
+++ b/programs/pkey/pk_decrypt.c
@@ -60,14 +60,6 @@ int main( void )
 }
 #else
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( int argc, char *argv[] )
 {
     FILE *f;

--- a/programs/pkey/pk_encrypt.c
+++ b/programs/pkey/pk_encrypt.c
@@ -60,14 +60,6 @@ int main( void )
 }
 #else
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( int argc, char *argv[] )
 {
     FILE *f;

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -59,14 +59,6 @@ int main( void )
 #include <stdio.h>
 #include <string.h>
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( int argc, char *argv[] )
 {
     FILE *f;

--- a/programs/pkey/pk_verify.c
+++ b/programs/pkey/pk_verify.c
@@ -55,14 +55,6 @@ int main( void )
 #include <stdio.h>
 #include <string.h>
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( int argc, char *argv[] )
 {
     FILE *f;

--- a/programs/pkey/rsa_decrypt.c
+++ b/programs/pkey/rsa_decrypt.c
@@ -59,14 +59,6 @@ int main( void )
 }
 #else
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( int argc, char *argv[] )
 {
     FILE *f;

--- a/programs/pkey/rsa_encrypt.c
+++ b/programs/pkey/rsa_encrypt.c
@@ -59,14 +59,6 @@ int main( void )
 }
 #else
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( int argc, char *argv[] )
 {
     FILE *f;

--- a/programs/pkey/rsa_genkey.c
+++ b/programs/pkey/rsa_genkey.c
@@ -63,14 +63,6 @@ int main( void )
 }
 #else
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( void )
 {
     int ret = 1;

--- a/programs/pkey/rsa_sign_pss.c
+++ b/programs/pkey/rsa_sign_pss.c
@@ -60,14 +60,6 @@ int main( void )
 #include <stdio.h>
 #include <string.h>
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( int argc, char *argv[] )
 {
     FILE *f;

--- a/programs/pkey/rsa_verify_pss.c
+++ b/programs/pkey/rsa_verify_pss.c
@@ -59,14 +59,6 @@ int main( void )
 #include <stdio.h>
 #include <string.h>
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( int argc, char *argv[] )
 {
     FILE *f;

--- a/programs/random/gen_random_ctr_drbg.c
+++ b/programs/random/gen_random_ctr_drbg.c
@@ -53,14 +53,6 @@ int main( void )
 }
 #else
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( int argc, char *argv[] )
 {
     FILE *f;

--- a/programs/ssl/dtls_client.c
+++ b/programs/ssl/dtls_client.c
@@ -79,14 +79,6 @@ int main( void )
 
 #define DEBUG_LEVEL 0
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 static void my_debug( void *ctx, int level,
                       const char *file, int line,
                       const char *str )

--- a/programs/ssl/dtls_server.c
+++ b/programs/ssl/dtls_server.c
@@ -88,14 +88,6 @@ int main( void )
 #define READ_TIMEOUT_MS 10000   /* 5 seconds */
 #define DEBUG_LEVEL 0
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 static void my_debug( void *ctx, int level,
                       const char *file, int line,
                       const char *str )

--- a/programs/ssl/mini_client.c
+++ b/programs/ssl/mini_client.c
@@ -168,14 +168,6 @@ enum exit_codes
     ssl_write_failed,
 };
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( void )
 {
     int ret = exit_ok;

--- a/programs/ssl/ssl_client1.c
+++ b/programs/ssl/ssl_client1.c
@@ -70,14 +70,6 @@ int main( void )
 
 #define DEBUG_LEVEL 1
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 static void my_debug( void *ctx, int level,
                       const char *file, int line,
                       const char *str )

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -314,14 +314,6 @@ int main( void )
 #define ALPN_LIST_SIZE  10
 #define CURVE_LIST_SIZE 20
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 /*
  * global options
  */

--- a/programs/ssl/ssl_fork_server.c
+++ b/programs/ssl/ssl_fork_server.c
@@ -86,14 +86,6 @@ int main( void )
 
 #define DEBUG_LEVEL 0
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 static void my_debug( void *ctx, int level,
                       const char *file, int line,
                       const char *str )

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -141,14 +141,6 @@ int main( void )
     "    force_ciphersuite=<name>    default: all enabled\n"\
     " acceptable ciphersuite names:\n"
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 /*
  * global options
  */

--- a/programs/ssl/ssl_server.c
+++ b/programs/ssl/ssl_server.c
@@ -80,14 +80,6 @@ int main( void )
 
 #define DEBUG_LEVEL 0
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 static void my_debug( void *ctx, int level,
                       const char *file, int line,
                       const char *str )

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -426,14 +426,6 @@ int main( void )
     (out_be)[(i) + 7] = (unsigned char)( ( (in_le) >> 0  ) & 0xFF );    \
 }
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 /*
  * global options
  */

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -254,14 +254,6 @@ typedef struct {
          rsa, dhm, ecdsa, ecdh;
 } todo_list;
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( int argc, char *argv[] )
 {
     int i;

--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -77,14 +77,6 @@
 #include "mbedtls/memory_buffer_alloc.h"
 #endif
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 static int test_snprintf( size_t n, const char ref_buf[10], int ref_ret )
 {
     int ret;
@@ -427,4 +419,3 @@ int main( int argc, char *argv[] )
     /* return() is here to prevent compiler warnings */
     return( MBEDTLS_EXIT_SUCCESS );
 }
-

--- a/programs/test/ssl_cert_test.c
+++ b/programs/test/ssl_cert_test.c
@@ -81,14 +81,6 @@ const char *client_private_keys[MAX_CLIENT_CERTS] =
     "cert_digest.key"
 };
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 int main( void )
 {
     int ret = 1, i;

--- a/programs/x509/cert_app.c
+++ b/programs/x509/cert_app.c
@@ -99,14 +99,6 @@ int main( void )
     "    permissive=%%d       default: 0 (disabled)\n"  \
     "\n"
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 /*
  * global options
  */

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -100,14 +100,6 @@ int main( void )
     "                          SHA384, SHA512\n"       \
     "\n"
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 /*
  * global options
  */

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -153,14 +153,6 @@ int main( void )
     "                            object_signing_ca\n"     \
     "\n"
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 /*
  * global options
  */

--- a/programs/x509/crl_app.c
+++ b/programs/x509/crl_app.c
@@ -60,14 +60,6 @@ int main( void )
     "    filename=%%s         default: crl.pem\n"      \
     "\n"
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 /*
  * global options
  */

--- a/programs/x509/req_app.c
+++ b/programs/x509/req_app.c
@@ -60,14 +60,6 @@ int main( void )
     "    filename=%%s         default: cert.req\n"      \
     "\n"
 
-#if defined( MBEDTLS_CHECK_PARAMS ) && defined(MBEDTLS_PLATFORM_C)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
-{
-    mbedtls_printf("%s:%i: Input param failed - %sn", file, line,                           failure_condition );
-    mbedtls_exit( MBEDTLS_EXIT_FAILURE );
-}
-#endif
-
 /*
  * global options
  */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@
 # To compile on SunOS: add "-lsocket -lnsl" to LDFLAGS
 # To compile with PKCS11: add "-lpkcs11-helper" to LDFLAGS
 
-CFLAGS	?= -O2
+CFLAGS	?= -O0
 WARNING_CFLAGS ?= -Wall -W -Wdeclaration-after-statement -Wno-unused-function -Wno-unused-value
 LDFLAGS ?=
 
@@ -135,4 +135,3 @@ $(EMBEDDED_TESTS): embedded_%: suites/$$(firstword $$(subst ., ,$$*)).function s
 		-o ./TESTS/mbedtls/$*
 
 generate-target-tests: $(EMBEDDED_TESTS)
-

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -320,7 +320,9 @@ static void platform_teardown()
 }
 
 #if defined(MBEDTLS_CHECK_PARAMS)
-void mbedtls_jump_param_failed( char* failure_condition, char* file, int line )
+void mbedtls_jump_param_failed( const char* failure_condition,
+                                const char* file,
+                                int line )
 {
     (void)failure_condition;
     (void)file;

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -6,6 +6,7 @@
 
 #if defined(MBEDTLS_PLATFORM_C)
 #include "mbedtls/platform.h"
+#include "mbedtls/platform_util.h"
 #else
 #include <stdio.h>
 #define mbedtls_fprintf    fprintf
@@ -25,7 +26,6 @@
 
 #if defined(MBEDTLS_CHECK_PARAMS)
 #include <setjmp.h>
-#define MBEDTLS_PARAM_FAILED(x)    mbedtls_param_failed( #x )
 #endif
 
 #ifdef _MSC_VER
@@ -320,7 +320,7 @@ static void platform_teardown()
 }
 
 #if defined(MBEDTLS_CHECK_PARAMS)
-void mbedtls_param_failed( char* failure_condition, char* file, int line )
+void mbedtls_jump_param_failed( char* failure_condition, char* file, int line )
 {
     (void)failure_condition;
     (void)file;
@@ -644,4 +644,3 @@ int hexcmp( uint8_t * a, uint8_t * b, uint32_t a_len, uint32_t b_len )
     }
     return ret;
 }
-

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -221,8 +221,10 @@ int main( int argc, const char *argv[] )
                          ret );
         return( -1 );
     }
+#if defined(MBEDTLS_CHECK_PARAMS)
+    mbedtls_set_param_failed( mbedtls_jump_param_failed );
+#endif
     ret = execute_tests( argc, argv );
     platform_teardown();
     return( ret );
 }
-

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -221,7 +221,7 @@ int main( int argc, const char *argv[] )
                          ret );
         return( -1 );
     }
-#if defined(MBEDTLS_CHECK_PARAMS)
+#if defined(MBEDTLS_CHECK_PARAMS) && defined(MBEDTLS_PARAM_FAILED_CALLBACK)
     mbedtls_set_param_failed( mbedtls_jump_param_failed );
 #endif
     ret = execute_tests( argc, argv );

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -377,7 +377,9 @@ void aes_invalid_param( )
     mbedtls_aes_context dummy_ctx;
     const unsigned char key[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
 
+#if defined(MBEDTLS_PARAM_FAILED_CALLBACK)
     TEST_INVALID_PARAM( mbedtls_aes_init( NULL ) );
+#endif
 
     /* mbedtls_aes_setkey_enc() */
     TEST_INVALID_PARAM_RET( MBEDTLS_ERR_AES_BAD_INPUT_DATA,

--- a/tests/suites/test_suite_aes.function
+++ b/tests/suites/test_suite_aes.function
@@ -371,7 +371,7 @@ exit:
 }
 /* END_CASE */
 
-/* BEGIN_CASE */
+/* BEGIN_CASE depends_on:MBEDTLS_CHECK_PARAMS */
 void aes_invalid_param( )
 {
     mbedtls_aes_context dummy_ctx;


### PR DESCRIPTION
This PR presents changes suggested for easier client side use of the parameter validation check failure. Limits the parameter validation failure callback to a default function provided with Mbed TLS, that can be substituted by user provided callback at run time.